### PR TITLE
20. FRONT CSS FIXED posts displaying vertically

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -70,6 +70,7 @@ h2{
     justify-content: center;
     align-items: center;
     height: 82.5vh;
+    width: 100%;
 }
 
 .landing-page,
@@ -215,12 +216,12 @@ h2{
     padding: 0.5%;
 }
 
-.posting-page {
+/* .posting-page {
     display: flex;
     justify-content: space-evenly;
     flex-wrap: wrap;
     width: 100%;
-}
+} */
 
 .post{
     margin: 2rem;
@@ -236,6 +237,7 @@ h2{
 
 .post-list {
     padding: 0;
+    list-style-type: none;
 }
 
 .post-item {

--- a/views/postings.handlebars
+++ b/views/postings.handlebars
@@ -1,4 +1,4 @@
-<section class="card postings-page">
+{{!-- <section class="card postings-page"> --}}
 {{#each postInfo}}
     <section class="post">
         {{!-- <section class="post-info"> --}}
@@ -12,4 +12,4 @@
         {{!-- </section> --}}
     </section>
 {{/each}}
-</section>
+{{!-- </section> --}}


### PR DESCRIPTION
Fixed an error where posts in posting.handlebars  was displaying vertically instead of horizontally as intended.